### PR TITLE
Allow to use absolute paths for ACME_ACCOUNT_KEY

### DIFF
--- a/bin/letsencrypt
+++ b/bin/letsencrypt
@@ -16,7 +16,7 @@ case ARGV.shift
 	when 'key'
 		options = OpenStruct.new type: Acme::PKI::DEFAULT_KEY
 		OptionParser.new do |opts|
-			opts.banner = "Usage: #{File.filename __FILE__} key <domain> [options]"
+			opts.banner = "Usage: #{File.basename __FILE__} key <domain> [options]"
 			opts.on('-r [KEYSIZE]', '--rsa [KEYSIZE]', 'RSA key, key size') { |k| options.type = [:rsa, k.to_i] }
 			opts.on('-e [CURVE]', '--ecc [CURVE]', 'ECC key, curve') { |k| options.type = [:ecc, k] }
 		end.parse!

--- a/lib/acme/pki.rb
+++ b/lib/acme/pki.rb
@@ -15,22 +15,23 @@ module Acme
 	class PKI
 		include Information
 
-		DEFAULT_ENDPOINT       = ENV['ACME_ENDPOINT'] || 'https://acme-v01.api.letsencrypt.org/'
-		DEFAULT_ACCOUNT_KEY    = ENV['ACME_ACCOUNT_KEY'] || 'account.key'
+		DEFAULT_ENDPOINT       = 'https://acme-v01.api.letsencrypt.org/'
+		DEFAULT_ACCOUNT_KEY    = 'account.key'
+		DEFAULT_CHALLENGE_DIR  = 'acme-challenge'
 		DEFAULT_KEY            = [:ecc, 'secp384r1']
 		#DEFAULT_KEY            = [:rsa, 4096]
 		DEFAULT_RENEW_DURATION = 60*60*24*30 # 1 month
 
-		def initialize(directory: Dir.pwd, account_key: DEFAULT_ACCOUNT_KEY, endpoint: DEFAULT_ENDPOINT)
+		def initialize(directory: Dir.pwd, account_key: nil, endpoint: nil, challenge_dir: nil)
 			@directory        = directory
-			@challenge_dir    = ENV['ACME_CHALLENGE'] || File.join(@directory, 'acme-challenge')
-			@account_key_file = File.join @directory, account_key
+			@challenge_dir    = challenge_dir || ENV['ACME_CHALLENGE'] || File.join(@directory, DEFAULT_CHALLENGE_DIR)
+			@account_key_file = account_key || ENV['ACME_ACCOUNT_KEY'] || File.join(@directory, DEFAULT_ACCOUNT_KEY)
 			@account_key      = if File.exists? @account_key_file
 									open(@account_key_file, 'r') { |f| OpenSSL::PKey.read f }
 								else
 									nil
 								end
-			@endpoint         = endpoint
+			@endpoint         = endpoint || ENV['ACME_ENDPOINT'] || DEFAULT_ENDPOINT
 		end
 
 		def key(name)


### PR DESCRIPTION
I did so by refactoring a bit the way parameters are handled by the PKI class.

Also fixed #2.
